### PR TITLE
[logging] std::cout wrappers

### DIFF
--- a/src/io.hpp
+++ b/src/io.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#ifdef DEBUG
+#define IMPLEMENTATION ;
+#else
+#define IMPLEMENTATION {}
+#endif
+
+namespace io {
+    template<typename T, typename ...Args>
+    void write(T t, Args ...args)IMPLEMENTATION
+
+    template<typename ...Args>
+    void print(Args ...args)IMPLEMENTATION
+
+    template<typename ...Args>
+    void trace(Args ...args)IMPLEMENTATION
+
+    void newline(unsigned int count)IMPLEMENTATION
+}
+
+#ifdef DEBUG
+#include "io.t.hpp"
+#endif

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -1,22 +1,22 @@
 #pragma once
 
 #ifdef DEBUG
-#define IMPLEMENTATION ;
+#define NO_IMPL ;
 #else
-#define IMPLEMENTATION {}
+#define NO_IMPL {}
 #endif
 
 namespace io {
     template<typename T, typename ...Args>
-    void write(T t, Args ...args)IMPLEMENTATION
+    void write(T t, Args ...args)NO_IMPL
 
     template<typename ...Args>
-    void print(Args ...args)IMPLEMENTATION
+    void print(Args ...args)NO_IMPL
 
     template<typename ...Args>
-    void trace(Args ...args)IMPLEMENTATION
+    void trace(Args ...args)NO_IMPL
 
-    void newline(unsigned int count)IMPLEMENTATION
+    void newline(unsigned int count)NO_IMPL
 }
 
 #ifdef DEBUG

--- a/src/io.t.hpp
+++ b/src/io.t.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#include "io.hpp"
+#include <iostream>
+
+template<typename T, typename ...Args>
+void io::write(T t, Args ...args) {
+    std::cout << t;
+    if constexpr (sizeof ...(Args) > 0) {
+        write(args...);
+    }
+}
+
+template<typename ...Args>
+void io::print(Args ...args) {
+    write(args...);
+    newline(1);
+}
+
+template<typename ...Args>
+void io::trace(Args ...args) {
+    for (const auto &arg : {args...}) {
+        write(arg);
+        newline(1);
+    }
+}
+
+void io::newline(unsigned int count = 1) {
+    while (count --> 0) {
+        std::cout << '\n';
+    }
+}


### PR DESCRIPTION
Implementation limited with **#define DEBUG**
- **write**: Prints all arguments after one another
- **print**: Prints all arguments after one another, and a newline at the end.
- **trace**: Prints all arguments on separate lines.
- **newline**: Prints the amount of newlines based on the given argument.